### PR TITLE
fix: Next.js 15 동적 라우트 params 타입 오류 수정

### DIFF
--- a/app/timer/[id]/completed/page.tsx
+++ b/app/timer/[id]/completed/page.tsx
@@ -6,9 +6,9 @@ import { TimerInformation } from '@/components/timer/information';
 import { ReportConfirmButton } from '@/components/timer/button/report-confirm';
 
 interface Props {
-  params: {
+  params: Promise<{
     id: number;
-  };
+  }>;
 }
 
 const Page = async ({ params }: Props) => {

--- a/app/timer/[id]/confirm/page.tsx
+++ b/app/timer/[id]/confirm/page.tsx
@@ -7,9 +7,9 @@ import CheckIcon from '@/assets/icon/check.svg';
 import { Actions } from './actions';
 
 interface Props {
-  params: {
+  params: Promise<{
     id: number;
-  };
+  }>;
 }
 
 const Page = async ({ params }: Props) => {

--- a/app/timer/[id]/fail/page.tsx
+++ b/app/timer/[id]/fail/page.tsx
@@ -4,9 +4,9 @@ import { fetchTimer } from '@/data/api/timer';
 import Link from 'next/link';
 
 interface Props {
-  params: {
+  params: Promise<{
     id: number;
-  };
+  }>;
 }
 
 const Page = async ({ params }: Props) => {

--- a/app/timer/[id]/progress/page.tsx
+++ b/app/timer/[id]/progress/page.tsx
@@ -7,9 +7,9 @@ import { TimerStopButton } from '@/components/timer/button/timer-stop';
 import { MoreButton } from '@/components/timer/button/more';
 
 interface Props {
-  params: {
+  params: Promise<{
     id: number;
-  };
+  }>;
 }
 
 const Page = async ({ params }: Props) => {

--- a/app/timer/[id]/report/page.tsx
+++ b/app/timer/[id]/report/page.tsx
@@ -1,4 +1,4 @@
-export const Page = () => {
+const Page = () => {
   return <div>Report Page</div>;
 };
 

--- a/app/timer/[id]/success/page.tsx
+++ b/app/timer/[id]/success/page.tsx
@@ -4,9 +4,9 @@ import { fetchTimer } from '@/data/api/timer';
 import Link from 'next/link';
 
 interface Props {
-  params: {
+  params: Promise<{
     id: number;
-  };
+  }>;
 }
 
 const Page = async ({ params }: Props) => {


### PR DESCRIPTION
## 수정사항
- Next.js 15에서 동적 라우트의 params가 Promise로 변경됨에 따른 타입 오류 수정

## 변경된 파일
- app/timer/[id]/completed/page.tsx
- app/timer/[id]/confirm/page.tsx
- app/timer/[id]/fail/page.tsx
- app/timer/[id]/progress/page.tsx
- app/timer/[id]/report/page.tsx (불필요한 named export 제거)
- app/timer/[id]/success/page.tsx

## 해결된 문제
- Vercel 배포 시 발생하던 타입 오류 해결
- 빌드 성공적으로 완료됨