### PR TITLE
feat: API URL 환경변수 설정 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# API Base URL
+NEXT_PUBLIC_API_BASE_URL=http://your-api-url.com

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/data/api.ts
+++ b/data/api.ts
@@ -1,4 +1,5 @@
 export const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL ||
   'http://heybit-backend-env.eba-ep9gaxub.ap-northeast-2.elasticbeanstalk.com';
 
 export const getServerToken = async () => {


### PR DESCRIPTION
## 변경사항
- API URL을 환경변수로 관리하도록 변경
- Vercel 배포 시 환경변수 설정 가능

## 추가된 파일
- `.env.example`: 환경변수 예시 파일

## 수정된 파일
- `data/api.ts`: process.env.NEXT_PUBLIC_API_BASE_URL 사용
- `.gitignore`: .env.example 파일은 커밋되도록 수정

## Vercel 설정
Dashboard에서 다음 환경변수 추가 필요:
- `NEXT_PUBLIC_API_BASE_URL`: API 서버 주소