### PR TITLE
feat: 사용자 프로필 API 연동 및 닉네임 표시

### DIFF
--- a/app/api/users/me/route.ts
+++ b/app/api/users/me/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { API_BASE_URL } from '@/data/api';
+
+export async function GET(request: NextRequest) {
+  const token = request.headers.get('authorization');
+
+  if (!token) {
+    return NextResponse.json({ error: '인증이 필요합니다' }, { status: 401 });
+  }
+
+  try {
+    const response = await fetch(
+      `${API_BASE_URL}/api/v1/users/me`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: token,
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch {
+    return NextResponse.json({ error: '서버 에러' }, { status: 500 });
+  }
+}

--- a/app/dashboard/vote/progress/page.tsx
+++ b/app/dashboard/vote/progress/page.tsx
@@ -1,7 +1,28 @@
+'use client';
+
 import { VoteCard } from '@/components/vote/VoteCard';
 import thumbnailImage from '@/assets/vote/thumbnail.png';
+import { useEffect, useState } from 'react';
+import { getUserProfile } from '@/data/api/user';
 
 export default function VotePage() {
+  const [nickname, setNickname] = useState<string>('사용자');
+
+  useEffect(() => {
+    const fetchUserProfile = async () => {
+      try {
+        const profile = await getUserProfile();
+        if (profile?.nickname) {
+          setNickname(profile.nickname);
+        }
+      } catch (error) {
+        console.error('Failed to fetch user profile:', error);
+      }
+    };
+
+    fetchUserProfile();
+  }, []);
+
   return (
     <div className="flex flex-col items-start relative pb-6">
       <div className="flex flex-col items-start gap-1 mb-6">
@@ -10,7 +31,7 @@ export default function VotePage() {
         </div>
         <p className="text-heybit-variable-HB-gray400 font-pretendard text-base font-medium leading-[140%]">
           <span className="underline decoration-solid decoration-auto underline-offset-auto">
-            닉네임최고길이테스트
+            {nickname}
           </span>
           <span>
             {' '}

--- a/data/api/user.ts
+++ b/data/api/user.ts
@@ -1,5 +1,36 @@
 import { getToken } from '../auth';
 
+export interface UserProfile {
+  id: number;
+  email: string;
+  nickname: string;
+  role: string;
+  status: string;
+}
+
+export const getUserProfile = async (): Promise<UserProfile> => {
+  const token = getToken();
+  
+  if (!token) {
+    throw new Error('No authentication token found');
+  }
+
+  const response = await fetch('/api/users/me', {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch user profile');
+  }
+
+  const data = await response.json();
+  return data.data;
+};
+
 export const checkNickname = async (nickname: string): Promise<boolean> => {
   const token = getToken();
   


### PR DESCRIPTION
## Summary
- 사용자 프로필 조회 API 연동
- 투표 진행 페이지에 실제 사용자 닉네임 표시
- JWT 디코딩 대신 API 호출 방식 적용

## Changes
- `/api/v1/users/me` 엔드포인트 연동을 위한 Next.js API 라우트 추가
- `getUserProfile` 함수 구현
- 투표 진행 페이지에 사용자 프로필 API 호출 및 닉네임 표시 기능 추가
- 사용하지 않는 JWT 디코딩 코드 제거