### PR TITLE
feat: 설문 제출 API 연동

### DIFF
--- a/app/api/surveys/route.ts
+++ b/app/api/surveys/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { API_BASE_URL } from '@/data/api';
+
+export async function POST(request: NextRequest) {
+  try {
+    const token = request.headers.get('authorization');
+    if (!token) {
+      return NextResponse.json({ error: '인증 토큰이 필요합니다' }, { status: 401 });
+    }
+
+    const body = await request.json();
+
+    const upstream = await fetch(`${API_BASE_URL}/api/v1/surveys`, {
+      method: 'POST',
+      headers: {
+        Authorization: token,
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    const json = await upstream.json().catch(() => ({}));
+    return NextResponse.json(json, { status: upstream.status });
+  } catch (e) {
+    return NextResponse.json({ error: '서버 오류' }, { status: 500 });
+  }
+}
+

--- a/app/api/surveys/route.ts
+++ b/app/api/surveys/route.ts
@@ -22,8 +22,7 @@ export async function POST(request: NextRequest) {
 
     const json = await upstream.json().catch(() => ({}));
     return NextResponse.json(json, { status: upstream.status });
-  } catch (e) {
+  } catch {
     return NextResponse.json({ error: '서버 오류' }, { status: 500 });
   }
 }
-

--- a/app/survey/four/page.tsx
+++ b/app/survey/four/page.tsx
@@ -6,12 +6,37 @@ import { Wrapper, TitleWrapper, Title } from './../styles';
 import SurveyItem from '@/components/survey/surveyItem';
 import FullButton from '@/components/button/fullButton';
 import { SurveyProgressBar } from '@/components/surveyProgressBar';
+import { SurveyStorage, mapImprovementReason } from '@/utils/survey';
+import { submitUserSurvey } from '@/data/api/survey';
 
 export default function SurveyPage() {
     const router = useRouter();
+    const [submitting, setSubmitting] = useState(false);
     
-    const handleStart = () => {
-        router.push('/register-complete');
+    const handleStart = async () => {
+        if (selectedItem !== null) {
+            SurveyStorage.setImprovementReason(mapImprovementReason(selectedItem));
+        }
+        const all = SurveyStorage.getAll();
+        if (!all.consumptionTime || !all.impulseFrequency || !all.purchaseTrigger || !all.improvementReason) {
+            alert('설문 응답을 모두 완료해주세요.');
+            return;
+        }
+
+        try {
+            setSubmitting(true);
+            await submitUserSurvey(all as any);
+            SurveyStorage.clear();
+            router.push('/register-complete');
+        } catch (e: any) {
+            if (e?.status === 400) {
+                router.push('/register-complete');
+                return;
+            }
+            alert('설문 제출에 실패했습니다. 잠시 후 다시 시도해주세요.');
+        } finally {
+            setSubmitting(false);
+        }
     }
 
     const [items] = useState([
@@ -41,7 +66,7 @@ export default function SurveyPage() {
             <FullButton 
                 style={{ marginTop: 'auto', marginBottom: '56px' }} 
                 onClick={handleStart}
-                disabled={selectedItem === null}
+                disabled={selectedItem === null || submitting}
             >
                 완료
             </FullButton>

--- a/app/survey/four/page.tsx
+++ b/app/survey/four/page.tsx
@@ -7,7 +7,7 @@ import SurveyItem from '@/components/survey/surveyItem';
 import FullButton from '@/components/button/fullButton';
 import { SurveyProgressBar } from '@/components/surveyProgressBar';
 import { SurveyStorage, mapImprovementReason } from '@/utils/survey';
-import { submitUserSurvey } from '@/data/api/survey';
+import { submitUserSurvey, type UserSurveyRequest } from '@/data/api/survey';
 
 export default function SurveyPage() {
     const router = useRouter();
@@ -25,11 +25,18 @@ export default function SurveyPage() {
 
         try {
             setSubmitting(true);
-            await submitUserSurvey(all as any);
+            const payload: UserSurveyRequest = {
+                consumptionTime: all.consumptionTime!,
+                impulseFrequency: all.impulseFrequency!,
+                purchaseTrigger: all.purchaseTrigger!,
+                improvementReason: all.improvementReason!,
+            };
+            await submitUserSurvey(payload);
             SurveyStorage.clear();
             router.push('/register-complete');
-        } catch (e: any) {
-            if (e?.status === 400) {
+        } catch (e: unknown) {
+            const status = (e as { status?: number } | undefined)?.status;
+            if (status === 400) {
                 router.push('/register-complete');
                 return;
             }

--- a/app/survey/one/page.tsx
+++ b/app/survey/one/page.tsx
@@ -6,11 +6,15 @@ import { Wrapper, TitleWrapper, Title } from './../styles';
 import SurveyItem from '@/components/survey/surveyItem';
 import FullButton from '@/components/button/fullButton';
 import { SurveyProgressBar } from '@/components/surveyProgressBar';
+import { SurveyStorage, mapConsumptionTime } from '@/utils/survey';
 
 export default function SurveyPage() {
     const router = useRouter();
     
     const handleStart = () => {
+        if (selectedItem !== null) {
+            SurveyStorage.setConsumptionTime(mapConsumptionTime(selectedItem));
+        }
         router.push('/survey/two');
     }
 

--- a/app/survey/three/page.tsx
+++ b/app/survey/three/page.tsx
@@ -6,11 +6,15 @@ import { Wrapper, TitleWrapper, Title } from './../styles';
 import SurveyItem from '@/components/survey/surveyItem';
 import FullButton from '@/components/button/fullButton';
 import { SurveyProgressBar } from '@/components/surveyProgressBar';
+import { SurveyStorage, mapPurchaseTrigger } from '@/utils/survey';
 
 export default function SurveyPage() {
     const router = useRouter();
     
     const handleStart = () => {
+        if (selectedItem !== null) {
+            SurveyStorage.setPurchaseTrigger(mapPurchaseTrigger(selectedItem));
+        }
         router.push('/survey/four');
     }
 

--- a/app/survey/two/page.tsx
+++ b/app/survey/two/page.tsx
@@ -6,11 +6,15 @@ import { Wrapper, TitleWrapper, Title, Description } from './../styles';
 import SurveyItem from '@/components/survey/surveyItem';
 import FullButton from '@/components/button/fullButton';
 import { SurveyProgressBar } from '@/components/surveyProgressBar';
+import { SurveyStorage, mapImpulseFrequency } from '@/utils/survey';
 
 export default function SurveyPage() {
     const router = useRouter();
     
     const handleStart = () => {
+        if (selectedItem !== null) {
+            SurveyStorage.setImpulseFrequency(mapImpulseFrequency(selectedItem));
+        }
         router.push('/survey/three');
     }
 

--- a/data/api/survey.ts
+++ b/data/api/survey.ts
@@ -1,0 +1,48 @@
+import { getToken } from '@/data/auth';
+
+export type ConsumptionTime = 'MORNING' | 'LUNCH' | 'AFTERNOON' | 'EVENING' | 'NIGHT' | 'DAWN';
+export type ImpulseFrequency = 'NONE' | 'ONE_TO_TWO' | 'LESS_THAN_FIVE' | 'MORE_THAN_FIVE';
+export type PurchaseTrigger =
+  | 'SELF_REWARD'
+  | 'DISTRACTED_BY_OTHER_PRODUCTS'
+  | 'INFLUENCED_BY_SNS_OR_YOUTUBE'
+  | 'BORED_OR_FREE_TIME'
+  | 'FRIEND_RECOMMENDATION';
+export type HabitImprovementReason =
+  | 'LACK_OF_WILLPOWER'
+  | 'HARD_TO_CONTROL_IMPULSE'
+  | 'TOO_BOTHERING'
+  | 'DON_T_KNOW_HOW'
+  | 'NO_VISIBLE_EFFECT';
+
+export interface UserSurveyRequest {
+  consumptionTime: ConsumptionTime;
+  impulseFrequency: ImpulseFrequency;
+  purchaseTrigger: PurchaseTrigger;
+  improvementReason: HabitImprovementReason;
+}
+
+export async function submitUserSurvey(payload: UserSurveyRequest): Promise<void> {
+  const token = getToken();
+  if (!token) throw new Error('No authentication token found');
+
+  const res = await fetch('/api/surveys', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    const msg = text || 'Failed to submit survey';
+    const err = new Error(msg);
+    // @ts-ignore add status for handling
+    (err as any).status = res.status;
+    throw err;
+  }
+}
+

--- a/utils/survey.ts
+++ b/utils/survey.ts
@@ -1,0 +1,116 @@
+import type {
+  ConsumptionTime,
+  HabitImprovementReason,
+  ImpulseFrequency,
+  PurchaseTrigger,
+  UserSurveyRequest,
+} from '@/data/api/survey';
+
+const K = {
+  consumptionTime: 'survey_consumptionTime',
+  impulseFrequency: 'survey_impulseFrequency',
+  purchaseTrigger: 'survey_purchaseTrigger',
+  improvementReason: 'survey_improvementReason',
+};
+
+export const SurveyStorage = {
+  setConsumptionTime(v: ConsumptionTime) {
+    if (typeof window !== 'undefined') localStorage.setItem(K.consumptionTime, v);
+  },
+  setImpulseFrequency(v: ImpulseFrequency) {
+    if (typeof window !== 'undefined') localStorage.setItem(K.impulseFrequency, v);
+  },
+  setPurchaseTrigger(v: PurchaseTrigger) {
+    if (typeof window !== 'undefined') localStorage.setItem(K.purchaseTrigger, v);
+  },
+  setImprovementReason(v: HabitImprovementReason) {
+    if (typeof window !== 'undefined') localStorage.setItem(K.improvementReason, v);
+  },
+  getAll(): Partial<UserSurveyRequest> {
+    if (typeof window === 'undefined') return {};
+    return {
+      consumptionTime: localStorage.getItem(K.consumptionTime) as ConsumptionTime | null | undefined,
+      impulseFrequency: localStorage.getItem(K.impulseFrequency) as ImpulseFrequency | null | undefined,
+      purchaseTrigger: localStorage.getItem(K.purchaseTrigger) as PurchaseTrigger | null | undefined,
+      improvementReason: localStorage.getItem(K.improvementReason) as HabitImprovementReason | null | undefined,
+    } as Partial<UserSurveyRequest>;
+  },
+  clear() {
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem(K.consumptionTime);
+      localStorage.removeItem(K.impulseFrequency);
+      localStorage.removeItem(K.purchaseTrigger);
+      localStorage.removeItem(K.improvementReason);
+    }
+  },
+};
+
+// ID -> enum mapping helpers for each step
+export function mapConsumptionTime(id: number): ConsumptionTime {
+  switch (id) {
+    case 1:
+      return 'EVENING';
+    case 2:
+      return 'NIGHT';
+    case 3:
+      return 'DAWN';
+    case 4:
+      return 'AFTERNOON';
+    case 5:
+      return 'MORNING';
+    case 6:
+      return 'LUNCH';
+    default:
+      return 'EVENING';
+  }
+}
+
+export function mapImpulseFrequency(id: number): ImpulseFrequency {
+  switch (id) {
+    case 4:
+      return 'NONE';
+    case 1:
+      return 'ONE_TO_TWO';
+    case 2:
+      return 'LESS_THAN_FIVE';
+    case 3:
+      return 'MORE_THAN_FIVE';
+    default:
+      return 'ONE_TO_TWO';
+  }
+}
+
+export function mapPurchaseTrigger(id: number): PurchaseTrigger {
+  switch (id) {
+    case 1:
+      return 'SELF_REWARD';
+    case 2:
+      return 'DISTRACTED_BY_OTHER_PRODUCTS';
+    case 3:
+      return 'INFLUENCED_BY_SNS_OR_YOUTUBE';
+    case 4:
+      return 'BORED_OR_FREE_TIME';
+    case 5:
+      return 'FRIEND_RECOMMENDATION';
+    default:
+      return 'SELF_REWARD';
+  }
+}
+
+export function mapImprovementReason(id: number): HabitImprovementReason {
+  switch (id) {
+    case 1:
+      return 'LACK_OF_WILLPOWER';
+    case 2:
+      return 'HARD_TO_CONTROL_IMPULSE';
+    case 3:
+      return 'TOO_BOTHERING';
+    case 4:
+      return "DON_T_KNOW_HOW";
+    case 5:
+      return 'NO_VISIBLE_EFFECT';
+    default:
+      return 'LACK_OF_WILLPOWER';
+  }
+}
+


### PR DESCRIPTION
설문 4단계 응답을 로컬스토리지에 보관하고 마지막 단계에서 /api/v1/surveys 로 제출하도록 연동했습니다. 
프록시 라우트(app/api/surveys) 및 매핑/스토리지 유틸 추가.